### PR TITLE
WIP: Don't flush large objects unless explicity dispatched

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,7 @@
 
 export const KEY_PREFIX = 'persist:'
 export const FLUSH = 'persist/FLUSH'
+export const FLUSH_LARGE_OBJECTS = 'persist/FLUSH_LARGE_OBJECTS'
 export const REHYDRATE = 'persist/REHYDRATE'
 export const PAUSE = 'persist/PAUSE'
 export const PERSIST = 'persist/PERSIST'

--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -23,13 +23,14 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   let timeIterator: ?number = null
   let writePromise = null
 
-  const update = (state: Object) => {
+  const update = (state: Object, includeLargeObjects = false) => {
     // add any changed keys to the queue
     Object.keys(state).forEach(key => {
       let subState = state[key]
       if (!passWhitelistBlacklist(key)) return // is keyspace ignored? noop
       if (lastState[key] === state[key]) return // value unchanged? noop
       if (keysToProcess.indexOf(key) !== -1) return // is key already queued? noop
+      if (key === "entities" && !includeLargeObjects) return;
       keysToProcess.push(key) // add key to queue
     })
 

--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -8,6 +8,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   // defaults
   const blacklist: ?Array<string> = config.blacklist || null
   const whitelist: ?Array<string> = config.whitelist || null
+  const largeObjects: ?Array<string> = config.largeObjects || null
   const transforms = config.transforms || []
   const throttle = config.throttle || 0
   const storageKey = `${config.keyPrefix !== undefined
@@ -30,7 +31,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
       if (!passWhitelistBlacklist(key)) return // is keyspace ignored? noop
       if (lastState[key] === state[key]) return // value unchanged? noop
       if (keysToProcess.indexOf(key) !== -1) return // is key already queued? noop
-      if (key === "entities" && !includeLargeObjects) return;
+      if (largeObjects.indexOf(key) && !includeLargeObjects) return;
       keysToProcess.push(key) // add key to queue
     })
 

--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -1,6 +1,7 @@
 // @flow
 import {
   FLUSH,
+  FLUSH_LARGE_OBJECTS,
   PAUSE,
   PERSIST,
   PURGE,
@@ -149,7 +150,7 @@ export default function persistReducer<State: Object, Action: Object>(
     _persist.rehydrated &&
       _persistoid &&
       !_paused &&
-      _persistoid.update(newState)
+      _persistoid.update(newState, action.type === FLUSH_LARGE_OBJECTS)
     return newState
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -16,6 +16,7 @@ export type PersistConfig = {
   keyPrefix?: string, // @TODO remove in v6
   blacklist?: Array<string>,
   whitelist?: Array<string>,
+  largeObjects?: Array<string>,
   transforms?: Array<Transform>,
   throttle?: number,
   migrate?: (PersistedState, number) => Promise<PersistedState>,


### PR DESCRIPTION
Better API would be to include list of large objects in config.